### PR TITLE
Add initial training pipeline skeleton

### DIFF
--- a/configs/rtx3070.yaml
+++ b/configs/rtx3070.yaml
@@ -1,0 +1,11 @@
+model: "Qwen/Qwen1.5-1.8B"
+dataset: "dataset/sample.tok"
+
+# LoRA hyper-parameters
+lora_r: 16
+lora_alpha: 32
+lora_dropout: 0.05
+
+# Training
+batch_size: 2
+epochs: 1

--- a/data/build_dataset.sh
+++ b/data/build_dataset.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Build the training dataset by fetching open-source code datasets and performing basic cleaning.
+# NOTE: This is a lightweight placeholder that shows how data could be prepared.
+
+set -euo pipefail
+
+DATA_DIR="$(pwd)/dataset"
+mkdir -p "$DATA_DIR"
+
+# Example: fetch a small subset of The Stack v2 from HuggingFace
+python - <<'PY'
+import datasets
+import os
+
+dataset = datasets.load_dataset('bigcode/the-stack-dedup', data_dir='data/python', split='train', streaming=True)
+# Keep only a small sample for demonstration
+sample = dataset.take(1000)
+
+os.makedirs('dataset', exist_ok=True)
+with open('dataset/sample.txt', 'w') as f:
+    for row in sample:
+        f.write(row['content'] + '\n')
+PY
+
+# Tokenise with tiktoken as an example
+python - <<'PY'
+import tiktoken
+
+enc = tiktoken.get_encoding('gpt2')
+with open('dataset/sample.txt') as f:
+    text = f.read()
+
+tokens = enc.encode(text)
+with open('dataset/sample.tok', 'w') as f:
+    f.write(' '.join(map(str, tokens)))
+PY
+
+echo "Dataset prepared at $DATA_DIR"

--- a/gui/gradio_app.py
+++ b/gui/gradio_app.py
@@ -1,0 +1,24 @@
+"""Simple Gradio interface for the trained model."""
+
+import gradio as gr
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+MODEL_DIR = "outputs/sft_model"
+
+def load_model():
+    tokenizer = AutoTokenizer.from_pretrained(MODEL_DIR)
+    model = AutoModelForCausalLM.from_pretrained(MODEL_DIR, device_map="auto")
+    return tokenizer, model
+
+tokenizer, model = load_model()
+
+
+def generate(prompt):
+    inputs = tokenizer(prompt, return_tensors="pt").to(model.device)
+    outputs = model.generate(**inputs, max_new_tokens=100)
+    return tokenizer.decode(outputs[0], skip_special_tokens=True)
+
+iface = gr.Interface(fn=generate, inputs="text", outputs="text")
+
+if __name__ == "__main__":
+    iface.launch()

--- a/instructions.txt
+++ b/instructions.txt
@@ -1,0 +1,68 @@
+# Getting Started with the RTX 3070 Code-Creation Agent
+
+This guide helps you set up and run the training pipeline on a single RTX 3070 with 8 GB of VRAM. No prior experience is required.
+
+## 1. Install Python and Create the Environment
+
+1. Install [Miniconda](https://docs.conda.io/en/latest/miniconda.html) if you do not already have it.
+2. Open a terminal and create a new environment:
+
+```bash
+conda create -n q3070 python=3.10 -y
+conda activate q3070
+```
+
+3. Install the required libraries:
+
+```bash
+pip install "unsloth[flash-attn]" transformers accelerate bitsandbytes peft \
+            datasets tiktoken wandb triton==2.1.0 ray==2.11.0 vllm==0.4.0
+```
+
+## 2. Prepare the Dataset
+
+The repository provides a script that downloads a small sample of The Stack dataset and tokenizes it.
+
+```bash
+bash data/build_dataset.sh
+```
+
+The processed data will be stored in the `dataset/` directory.
+
+## 3. Download Base Model Weights (4-bit)
+
+Use the helper script to download the base model in 4-bit form:
+
+```bash
+python scripts/pull_4bit.py
+```
+
+This creates the `models/4bit/` directory with the model and tokenizer.
+
+## 4. Run the Training Pipeline
+
+Launch the simplified training pipeline, which performs supervised fine-tuning and shows where later stages would go:
+
+```bash
+python pipelines/train_full.py --config configs/rtx3070.yaml
+```
+
+Training outputs are saved under `outputs/`.
+
+## 5. Launch the Gradio Interface
+
+After training, you can test the model with the Gradio web UI:
+
+```bash
+python gui/gradio_app.py
+```
+
+A local web server will open in your browser where you can submit prompts.
+
+## Troubleshooting
+
+- **Out of Memory (OOM)**: reduce the `batch_size` or sequence length in `configs/rtx3070.yaml`.
+- **Slow training**: remove `gradient_checkpointing` or lower LoRA ranks.
+- **Dataset script fails**: ensure you have an internet connection when downloading datasets.
+
+For additional details, see `README.md`.

--- a/pipelines/train_full.py
+++ b/pipelines/train_full.py
@@ -1,0 +1,66 @@
+"""Full training pipeline: SFT -> GRM -> Alpha-Evolve.
+This is heavily simplified and intended as a placeholder.
+"""
+
+import argparse
+from pathlib import Path
+
+import torch
+from transformers import AutoTokenizer, AutoModelForCausalLM, Trainer, TrainingArguments
+from datasets import load_dataset
+from peft import LoraConfig, get_peft_model
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", type=str, required=True)
+    return parser.parse_args()
+
+
+def load_config(path):
+    import yaml
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def prepare_dataset(cfg):
+    ds = load_dataset("text", data_files=cfg["dataset"], split="train")
+    return ds
+
+
+def train_sft(cfg, model, tokenizer, dataset):
+    lora = LoraConfig(r=cfg["lora_r"], lora_alpha=cfg["lora_alpha"], lora_dropout=cfg["lora_dropout"])
+    model = get_peft_model(model, lora)
+
+    training_args = TrainingArguments(
+        output_dir="outputs/sft",
+        per_device_train_batch_size=cfg["batch_size"],
+        num_train_epochs=cfg["epochs"],
+        gradient_checkpointing=True,
+        fp16=True,
+        logging_steps=10,
+        save_steps=500,
+    )
+
+    trainer = Trainer(model=model, args=training_args, train_dataset=dataset)
+    trainer.train()
+    model.save_pretrained("outputs/sft_model")
+    tokenizer.save_pretrained("outputs/sft_model")
+
+
+def main():
+    args = parse_args()
+    cfg = load_config(args.config)
+
+    tokenizer = AutoTokenizer.from_pretrained(cfg["model"])
+    model = AutoModelForCausalLM.from_pretrained(cfg["model"], load_in_4bit=True, device_map="auto")
+
+    dataset = prepare_dataset(cfg)
+
+    train_sft(cfg, model, tokenizer, dataset)
+
+    # Placeholder for GRM-lite and Alpha-Evolve steps
+    print("[INFO] GRM-lite and Alpha-Evolve steps would run here.")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/pull_4bit.py
+++ b/scripts/pull_4bit.py
@@ -1,0 +1,25 @@
+"""Download a base model and prepare 4-bit weights for training.
+This is a minimal example using HuggingFace Transformers and bitsandbytes.
+"""
+
+from transformers import AutoModelForCausalLM, AutoTokenizer
+import transformers
+import torch
+
+MODEL_NAME = "Qwen/Qwen1.5-1.8B"
+OUTPUT_DIR = "models/4bit"
+
+def main():
+    model = AutoModelForCausalLM.from_pretrained(
+        MODEL_NAME,
+        load_in_4bit=True,
+        device_map="auto",
+        torch_dtype=torch.float16,
+    )
+    tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)
+    model.save_pretrained(OUTPUT_DIR)
+    tokenizer.save_pretrained(OUTPUT_DIR)
+    print(f"Model saved to {OUTPUT_DIR}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create directories for dataset building, training, configs and GUI
- add placeholder dataset builder and 4-bit weight download script
- implement a minimal training pipeline using LoRA
- include a simple Gradio interface and example config

## Testing
- `python -m py_compile scripts/pull_4bit.py pipelines/train_full.py gui/gradio_app.py`
- `bash -n data/build_dataset.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fa51c4aec8327b6242207e9069b4a