### PR TITLE
Add simple DGM loop and integration

### DIFF
--- a/dgm/archive.py
+++ b/dgm/archive.py
@@ -1,0 +1,41 @@
+import json
+from pathlib import Path
+
+
+class Archive:
+    """Simple archive tracking DGM agents and best score."""
+
+    def __init__(self, path: str = "outputs/dgm_archive.json"):
+        self.path = Path(path)
+        if self.path.exists():
+            with open(self.path) as f:
+                data = json.load(f)
+            self.agents = data.get("agents", {})
+            self.best_id = data.get("best_id")
+            self.best_score = data.get("best_score", 0.0)
+        else:
+            self.agents = {}
+            self.best_id = None
+            self.best_score = 0.0
+
+    def add(self, agent_id: str, score: float, config: dict):
+        self.agents[agent_id] = {"score": score, "config": config}
+        if score > self.best_score:
+            self.best_score = score
+            self.best_id = agent_id
+
+    def get_best(self):
+        return self.best_id, self.best_score
+
+    def save(self):
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with open(self.path, "w") as f:
+            json.dump(
+                {
+                    "agents": self.agents,
+                    "best_id": self.best_id,
+                    "best_score": self.best_score,
+                },
+                f,
+            )
+

--- a/dgm/loop.py
+++ b/dgm/loop.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+from .archive import Archive
+from .mutate import mutate
+from .validate import evaluate
+
+
+BEST_INFO_PATH = Path("outputs/dgm_best.json")
+
+
+def save_best_info(agent_id: str, score: float, path: Path = BEST_INFO_PATH):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "{" + f"\"agent_id\": \"{agent_id}\", \"score\": {score}" + "}"
+    )
+
+
+def run(generations: int = 2, population: int = 2, archive_path: str = "outputs/dgm_archive.json"):
+    """Run a tiny DGM loop."""
+    base_cfg = {"lr": 1e-4, "lora_r": 16}
+    archive = Archive(archive_path)
+
+    for _ in range(generations):
+        for _ in range(population):
+            agent_id, cfg = mutate(base_cfg)
+            score = evaluate(agent_id, cfg)
+            archive.add(agent_id, score, cfg)
+
+    archive.save()
+    best_id, best_score = archive.get_best()
+    if best_id is not None:
+        save_best_info(best_id, best_score, BEST_INFO_PATH)
+    print(f"[DGM] Best agent {best_id} score {best_score:.3f}")
+    return best_id, best_score
+

--- a/dgm/mutate.py
+++ b/dgm/mutate.py
@@ -1,0 +1,17 @@
+import copy
+import random
+import uuid
+
+
+def mutate(config: dict) -> tuple[str, dict]:
+    """Return a new agent id and mutated config."""
+    new_config = copy.deepcopy(config)
+    # Example hyper-params
+    if "lr" in new_config:
+        new_config["lr"] *= random.uniform(0.8, 1.2)
+    if "lora_r" in new_config:
+        delta = random.choice([-1, 1]) * random.randint(0, 2)
+        new_config["lora_r"] = max(1, new_config["lora_r"] + delta)
+    agent_id = str(uuid.uuid4())[:8]
+    return agent_id, new_config
+

--- a/dgm/validate.py
+++ b/dgm/validate.py
@@ -1,0 +1,8 @@
+import random
+
+
+def evaluate(agent_id: str, config: dict) -> float:
+    """Placeholder evaluation returning a random score."""
+    random.seed(hash(agent_id) % 2**32)
+    return random.random()
+

--- a/gui/gradio_app.py
+++ b/gui/gradio_app.py
@@ -1,5 +1,8 @@
 """Simple Gradio interface for the trained model."""
 
+import json
+from pathlib import Path
+
 import gradio as gr
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
@@ -12,13 +15,27 @@ def load_model():
 
 tokenizer, model = load_model()
 
+BEST_INFO_PATH = Path("outputs/dgm_best.json")
+
+
+def best_summary() -> str:
+    if BEST_INFO_PATH.exists():
+        data = json.loads(BEST_INFO_PATH.read_text())
+        return f"Best DGM agent: {data['agent_id']} (score {data['score']:.3f})"
+    return "Best DGM agent: N/A"
+
 
 def generate(prompt):
     inputs = tokenizer(prompt, return_tensors="pt").to(model.device)
     outputs = model.generate(**inputs, max_new_tokens=100)
     return tokenizer.decode(outputs[0], skip_special_tokens=True)
 
-iface = gr.Interface(fn=generate, inputs="text", outputs="text")
+iface = gr.Interface(
+    fn=generate,
+    inputs="text",
+    outputs="text",
+    description=best_summary(),
+)
 
 if __name__ == "__main__":
     iface.launch()

--- a/pipelines/train_full.py
+++ b/pipelines/train_full.py
@@ -14,6 +14,11 @@ from peft import LoraConfig, get_peft_model
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--config", type=str, required=True)
+    parser.add_argument(
+        "--no_dgm",
+        action="store_true",
+        help="Skip the lightweight DGM loop after Alpha-Evolve",
+    )
     return parser.parse_args()
 
 
@@ -61,6 +66,10 @@ def main():
 
     # Placeholder for GRM-lite and Alpha-Evolve steps
     print("[INFO] GRM-lite and Alpha-Evolve steps would run here.")
+
+    if not args.no_dgm:
+        from dgm.loop import run as dgm_run
+        dgm_run()
 
 if __name__ == "__main__":
     main()

--- a/tests/test_dgm.py
+++ b/tests/test_dgm.py
@@ -1,0 +1,46 @@
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from dgm.archive import Archive
+from dgm.mutate import mutate
+from dgm.validate import evaluate
+from dgm import loop
+
+
+def test_archive_add_and_best(tmp_path):
+    path = tmp_path / "archive.json"
+    arch = Archive(path)
+    arch.add("a1", 0.1, {})
+    arch.add("a2", 0.5, {})
+    arch.save()
+
+    arch2 = Archive(path)
+    assert arch2.get_best() == ("a2", 0.5)
+
+
+def test_mutate_changes_params():
+    cfg = {"lr": 1.0, "lora_r": 16}
+    agent_id, new_cfg = mutate(cfg)
+    assert agent_id
+    # Likely mutated
+    assert new_cfg != cfg
+
+
+def test_validate_bounds():
+    score = evaluate("agent", {})
+    assert 0.0 <= score <= 1.0
+
+
+def test_loop_runs(tmp_path):
+    arch_path = tmp_path / "archive.json"
+    best_path = tmp_path / "best.json"
+    loop.BEST_INFO_PATH = best_path
+    best_id, best_score = loop.run(generations=1, population=1, archive_path=str(arch_path))
+    assert arch_path.exists()
+    data = json.loads(arch_path.read_text())
+    assert data["best_id"] == best_id
+    assert best_path.exists()


### PR DESCRIPTION
## Summary
- add simple DGM modules (`archive`, `mutate`, `validate`, `loop`)
- integrate DGM loop in training pipeline
- show best DGM agent in Gradio GUI
- provide unit tests for DGM utilities

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683faa28cd0083279e9c074b0099c07f