### PR TITLE
Add simple evaluation harness

### DIFF
--- a/eval/run_all.py
+++ b/eval/run_all.py
@@ -1,0 +1,70 @@
+import argparse
+import json
+from pathlib import Path
+
+import torch
+from transformers import AutoTokenizer, AutoModelForCausalLM
+from datasets import load_dataset
+from human_eval.data import read_problems
+from human_eval.execution import check_correctness
+from human_eval.evaluation import write_jsonl
+
+
+def generate_completion(model, tokenizer, prompt, max_new_tokens=256):
+    inputs = tokenizer.encode(prompt, return_tensors="pt").to(model.device)
+    outputs = model.generate(inputs, max_new_tokens=max_new_tokens)
+    return tokenizer.decode(outputs[0], skip_special_tokens=True)
+
+
+def run_humaneval(ckpt_path: str, out_dir: Path):
+    out_dir.mkdir(parents=True, exist_ok=True)
+    tokenizer = AutoTokenizer.from_pretrained(ckpt_path, trust_remote_code=True)
+    model = AutoModelForCausalLM.from_pretrained(ckpt_path, trust_remote_code=True)
+    model.to("cuda" if torch.cuda.is_available() else "cpu")
+
+    samples = []
+    for task_id, task in read_problems().items():
+        completion = generate_completion(model, tokenizer, task["prompt"])
+        samples.append({"task_id": task_id, "completion": completion})
+
+    samples_file = out_dir / "humaneval_samples.jsonl"
+    write_jsonl(samples_file, samples)
+    results = check_correctness(str(samples_file), k=[1])
+    with open(out_dir / "humaneval_results.json", "w") as f:
+        json.dump(results, f, indent=2)
+    print("HumanEval results:", results)
+
+
+def run_apps_dev_med(ckpt_path: str, out_dir: Path):
+    out_dir.mkdir(parents=True, exist_ok=True)
+    tokenizer = AutoTokenizer.from_pretrained(ckpt_path, trust_remote_code=True)
+    model = AutoModelForCausalLM.from_pretrained(ckpt_path, trust_remote_code=True)
+    model.to("cuda" if torch.cuda.is_available() else "cpu")
+
+    ds = load_dataset("minimario/apps_partial_sorted_0_300", split="train[:10]", trust_remote_code=True)
+    correct = 0
+    for row in ds:
+        completion = generate_completion(model, tokenizer, row["problem"])
+        if completion.strip() == row["full_sample"].strip():
+            correct += 1
+    acc = correct / len(ds)
+    result = {"accuracy": acc}
+    with open(out_dir / "apps_dev_med_results.json", "w") as f:
+        json.dump(result, f, indent=2)
+    print("APPS-Dev-Med accuracy:", acc)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Run code benchmarks")
+    parser.add_argument("--ckpt", type=str, required=True)
+    parser.add_argument("--subset", type=str, default="humaneval,apps_dev_med")
+    parser.add_argument("--out", type=str, default="eval_results")
+    args = parser.parse_args()
+
+    subsets = [s.strip() for s in args.subset.split(",") if s.strip()]
+    out_dir = Path(args.out)
+
+    if "humaneval" in subsets:
+        run_humaneval(args.ckpt, out_dir / "humaneval")
+    if "apps_dev_med" in subsets:
+        run_apps_dev_med(args.ckpt, out_dir / "apps_dev_med")

--- a/instructions.txt
+++ b/instructions.txt
@@ -59,6 +59,18 @@ python gui/gradio_app.py
 
 A local web server will open in your browser where you can submit prompts.
 
+## 6. Run Benchmark Evaluations
+
+Use the helper script in `eval/` to evaluate a checkpoint on HumanEval and a
+small APPS subset. Provide the path to your model and choose the benchmark
+subset:
+
+```bash
+python eval/run_all.py --ckpt <path-to-checkpoint> --subset humaneval,apps_dev_med
+```
+
+Results are written under the `eval_results/` directory by default.
+
 ## Troubleshooting
 
 - **Out of Memory (OOM)**: reduce the `batch_size` or sequence length in `configs/rtx3070.yaml`.


### PR DESCRIPTION
## Summary
- add `eval/run_all.py` for running HumanEval and a small APPS subset
- document running the benchmarks in `instructions.txt`

## Testing
- `python -m py_compile eval/run_all.py`

------
https://chatgpt.com/codex/tasks/task_e_683faa95de04832790f38a5231b27121