### PR TITLE
Add unit tests for dataset script and argument parsing

### DIFF
--- a/tests/fake_modules/datasets/__init__.py
+++ b/tests/fake_modules/datasets/__init__.py
@@ -1,0 +1,8 @@
+"""Fake datasets module for tests"""
+
+def load_dataset(*args, **kwargs):
+    class Dummy:
+        def take(self, n):
+            for i in range(n):
+                yield {"content": f"sample {i}"}
+    return Dummy()

--- a/tests/fake_modules/tiktoken/__init__.py
+++ b/tests/fake_modules/tiktoken/__init__.py
@@ -1,0 +1,8 @@
+"""Fake tiktoken module for tests"""
+
+class DummyEnc:
+    def encode(self, text):
+        return [ord(c) for c in text]
+
+def get_encoding(name):
+    return DummyEnc()

--- a/tests/test_build_dataset.py
+++ b/tests/test_build_dataset.py
@@ -1,0 +1,18 @@
+import subprocess
+import os
+from pathlib import Path
+
+def test_build_dataset(tmp_path):
+    repo = Path(__file__).resolve().parents[1]
+    script = repo / 'data' / 'build_dataset.sh'
+    env = os.environ.copy()
+    env['PYTHONPATH'] = str(repo / 'tests' / 'fake_modules')
+    subprocess.check_call(['bash', str(script)], cwd=tmp_path, env=env)
+
+    dataset_dir = tmp_path / 'dataset'
+    sample = dataset_dir / 'sample.txt'
+    tokens = dataset_dir / 'sample.tok'
+    assert sample.exists()
+    assert tokens.exists()
+    assert sample.stat().st_size > 0
+    assert tokens.stat().st_size > 0

--- a/tests/test_train_full.py
+++ b/tests/test_train_full.py
@@ -1,0 +1,51 @@
+import sys
+import types
+import importlib
+import importlib.util
+from pathlib import Path
+from unittest import mock
+import pytest
+
+
+def import_with_stubs(monkeypatch):
+    # Remove cached module if present
+    if 'pipelines.train_full' in sys.modules:
+        del sys.modules['pipelines.train_full']
+
+    # Stub heavy dependencies
+    monkeypatch.setitem(sys.modules, 'torch', types.ModuleType('torch'))
+
+    tfm = types.ModuleType('transformers')
+    tfm.AutoTokenizer = object
+    tfm.AutoModelForCausalLM = object
+    tfm.Trainer = object
+    tfm.TrainingArguments = object
+    monkeypatch.setitem(sys.modules, 'transformers', tfm)
+
+    dsets = types.ModuleType('datasets')
+    dsets.load_dataset = lambda *a, **k: None
+    monkeypatch.setitem(sys.modules, 'datasets', dsets)
+
+    peft = types.ModuleType('peft')
+    peft.LoraConfig = object
+    peft.get_peft_model = lambda m, c: m
+    monkeypatch.setitem(sys.modules, 'peft', peft)
+
+    # Import the module from its path to avoid package issues
+    path = Path(__file__).resolve().parents[1] / 'pipelines' / 'train_full.py'
+    spec = importlib.util.spec_from_file_location('train_full', path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_argument_parsing(monkeypatch):
+    mod = import_with_stubs(monkeypatch)
+
+    with mock.patch.object(sys, 'argv', ['prog', '--config', 'cfg.yaml']):
+        args = mod.parse_args()
+    assert args.config == 'cfg.yaml'
+
+    with mock.patch.object(sys, 'argv', ['prog']):
+        with pytest.raises(SystemExit):
+            mod.parse_args()


### PR DESCRIPTION
## Summary
- add fake `datasets` and `tiktoken` modules for tests
- test `data/build_dataset.sh` via subprocess
- test `pipelines/train_full.py` argument parsing with stubbed deps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683faa97c730832795bc7595b4524520