### PR TITLE
Add seed option and logging

### DIFF
--- a/instructions.txt
+++ b/instructions.txt
@@ -49,6 +49,8 @@ python pipelines/train_full.py --config configs/rtx3070.yaml
 
 Training outputs are saved under `outputs/`.
 
+The chosen seed and config are logged to `outputs/run.log`.
+
 Use `--seed` to fix the random seed for reproducible runs (default is `42`):
 
 ```bash

--- a/instructions.txt
+++ b/instructions.txt
@@ -49,6 +49,12 @@ python pipelines/train_full.py --config configs/rtx3070.yaml
 
 Training outputs are saved under `outputs/`.
 
+Use `--seed` to fix the random seed for reproducible runs (default is `42`):
+
+```bash
+python pipelines/train_full.py --config configs/rtx3070.yaml --seed 1234
+```
+
 ## 5. Launch the Gradio Interface
 
 After training, you can test the model with the Gradio web UI:

--- a/instructions.txt
+++ b/instructions.txt
@@ -49,7 +49,8 @@ python pipelines/train_full.py --config configs/rtx3070.yaml
 
 Training outputs are saved under `outputs/`.
 
-The chosen seed and config are logged to `outputs/run.log`.
+The chosen seed and configuration are appended as YAML documents in
+`outputs/run.log`.
 
 Use `--seed` to fix the random seed for reproducible runs (default is `42`):
 

--- a/pipelines/train_full.py
+++ b/pipelines/train_full.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import random
 import torch
 import numpy as np
+import yaml
 from transformers import AutoTokenizer, AutoModelForCausalLM, Trainer, TrainingArguments
 from datasets import load_dataset
 from peft import LoraConfig, get_peft_model
@@ -31,17 +32,15 @@ def set_seed(seed: int):
 
 def log_run(cfg, seed: int):
     """Log configuration and seed to outputs directory."""
-    import yaml
     out_dir = Path("outputs")
     out_dir.mkdir(exist_ok=True)
     log_file = out_dir / "run.log"
-    with open(log_file, "w") as f:
-        yaml.dump(cfg, f)
-        f.write(f"\nseed: {seed}\n")
+    with open(log_file, "a") as f:
+        yaml.safe_dump(cfg, f)
+        f.write(f"seed: {seed}\n")
 
 
 def load_config(path):
-    import yaml
     with open(path) as f:
         return yaml.safe_load(f)
 

--- a/pipelines/train_full.py
+++ b/pipelines/train_full.py
@@ -5,7 +5,9 @@ This is heavily simplified and intended as a placeholder.
 import argparse
 from pathlib import Path
 
+import random
 import torch
+import numpy as np
 from transformers import AutoTokenizer, AutoModelForCausalLM, Trainer, TrainingArguments
 from datasets import load_dataset
 from peft import LoraConfig, get_peft_model
@@ -14,7 +16,28 @@ from peft import LoraConfig, get_peft_model
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--config", type=str, required=True)
+    parser.add_argument("--seed", type=int, default=42, help="Random seed")
     return parser.parse_args()
+
+
+def set_seed(seed: int):
+    """Set random seeds for reproducibility."""
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+
+def log_run(cfg, seed: int):
+    """Log configuration and seed to outputs directory."""
+    import yaml
+    out_dir = Path("outputs")
+    out_dir.mkdir(exist_ok=True)
+    log_file = out_dir / "run.log"
+    with open(log_file, "w") as f:
+        yaml.dump(cfg, f)
+        f.write(f"\nseed: {seed}\n")
 
 
 def load_config(path):
@@ -51,6 +74,8 @@ def train_sft(cfg, model, tokenizer, dataset):
 def main():
     args = parse_args()
     cfg = load_config(args.config)
+    set_seed(args.seed)
+    log_run(cfg, args.seed)
 
     tokenizer = AutoTokenizer.from_pretrained(cfg["model"])
     model = AutoModelForCausalLM.from_pretrained(cfg["model"], load_in_4bit=True, device_map="auto")

--- a/pipelines/train_full.py
+++ b/pipelines/train_full.py
@@ -35,9 +35,10 @@ def log_run(cfg, seed: int):
     out_dir = Path("outputs")
     out_dir.mkdir(exist_ok=True)
     log_file = out_dir / "run.log"
+    # Append run information as a single YAML document
+    log_data = {"config": cfg, "seed": seed}
     with open(log_file, "a") as f:
-        yaml.safe_dump(cfg, f)
-        f.write(f"seed: {seed}\n")
+        yaml.safe_dump(log_data, f, explicit_start=True)
 
 
 def load_config(path):


### PR DESCRIPTION
## Summary
- add `--seed` option to `train_full.py`
- log config and random seed in `outputs/run.log`
- document `--seed` usage in `instructions.txt`

## Testing
- `python -m py_compile pipelines/train_full.py`


------
https://chatgpt.com/codex/tasks/task_e_683faa9aa8388327846a7846c30610ce