### PR TITLE
Add model export options

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ After training completes, the user will want to use the fine-tuned model elsewhe
 
 We ensure the user can choose either or both export formats. The UI might have an “Export Model” dialog with checkboxes for “FP16” and “AWQ 4-bit”. Upon export, the app merges weights as needed and then either directly saves FP16, or calls the AWQ conversion pipeline. We cite that AWQ was an MLSys 2024-winning approach for accurate 4-bit quantization, underscoring that this isn’t a naive quantization but a proven method. For the user, the exported int4 model allows them to run the model in lightweight environments (even possibly on the CPU or smaller GPU, since 0.6B at 4-bit will be very small). The FP16 model is there for compatibility or if they wish to fine-tune further elsewhere.
 
+Developers using the command-line training script can invoke these exports directly. Running `python pipelines/train_full.py --config <cfg> --export_fp16` merges LoRA weights into an FP16 model, while adding `--export_awq` performs an additional AWQ int4 quantization step.
+
 All exported models, logs, and any other artifacts can be bundled if the user wants to share their trained model. The app could even integrate a direct uploader to Hugging Face Hub (using their API) to make sharing easy, though that’s an optional feature.
 
 ## Packaging and Distribution

--- a/pipelines/train_full.py
+++ b/pipelines/train_full.py
@@ -19,6 +19,16 @@ def parse_args():
         action="store_true",
         help="Skip the lightweight DGM loop after Alpha-Evolve",
     )
+    parser.add_argument(
+        "--export_fp16",
+        action="store_true",
+        help="Merge LoRA weights and export an FP16 model",
+    )
+    parser.add_argument(
+        "--export_awq",
+        action="store_true",
+        help="Quantize the merged model to AWQ int4 format",
+    )
     return parser.parse_args()
 
 
@@ -53,6 +63,33 @@ def train_sft(cfg, model, tokenizer, dataset):
     tokenizer.save_pretrained("outputs/sft_model")
 
 
+def export_fp16(model, tokenizer, out_dir="outputs/fp16_model"):
+    """Merge LoRA weights and save an FP16 model."""
+    try:
+        merged = model.merge_and_unload()
+    except AttributeError:
+        # If the model is already merged, proceed.
+        merged = model
+    Path(out_dir).mkdir(parents=True, exist_ok=True)
+    merged.save_pretrained(out_dir)
+    tokenizer.save_pretrained(out_dir)
+    return out_dir
+
+
+def export_awq(src_dir, out_dir="outputs/awq_model"):
+    """Quantize a model directory to AWQ int4 format."""
+    try:
+        from awq import AutoAWQForCausalLM
+    except Exception:
+        print("[WARN] AutoAWQ not installed; skipping AWQ export.")
+        return
+
+    model = AutoAWQForCausalLM.from_pretrained(src_dir)
+    tokenizer = AutoTokenizer.from_pretrained(src_dir)
+    model.quantize(tokenizer, out_dir)
+    print(f"[INFO] AWQ model saved to {out_dir}")
+
+
 def main():
     args = parse_args()
     cfg = load_config(args.config)
@@ -63,6 +100,11 @@ def main():
     dataset = prepare_dataset(cfg)
 
     train_sft(cfg, model, tokenizer, dataset)
+
+    if args.export_fp16 or args.export_awq:
+        fp16_dir = export_fp16(model, tokenizer)
+        if args.export_awq:
+            export_awq(fp16_dir)
 
     # Placeholder for GRM-lite and Alpha-Evolve steps
     print("[INFO] GRM-lite and Alpha-Evolve steps would run here.")

--- a/tests/test_train_full.py
+++ b/tests/test_train_full.py
@@ -42,9 +42,12 @@ def import_with_stubs(monkeypatch):
 def test_argument_parsing(monkeypatch):
     mod = import_with_stubs(monkeypatch)
 
-    with mock.patch.object(sys, 'argv', ['prog', '--config', 'cfg.yaml']):
+    with mock.patch.object(sys, 'argv', ['prog', '--config', 'cfg.yaml', '--export_fp16', '--export_awq', '--no_dgm']):
         args = mod.parse_args()
     assert args.config == 'cfg.yaml'
+    assert args.export_fp16 is True
+    assert args.export_awq is True
+    assert args.no_dgm is True
 
     with mock.patch.object(sys, 'argv', ['prog']):
         with pytest.raises(SystemExit):


### PR DESCRIPTION
## Summary
- extend training CLI with `--export_fp16` and `--export_awq` to merge LoRA weights and optionally quantize to AWQ
- document new export flags in README
- test argument parsing for the export options

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689661034a1c832798c76560246e84f8